### PR TITLE
Update rune enums layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrConfig.java
@@ -18,20 +18,8 @@ public interface GotrConfig extends Config {
     String maxFragmentAmount = "maxFragmentAmount";
     String maxAmountEssence = "maxAmountEssence";
     String shouldDepositRunes = "shouldDepositRunes";
-    String enabled = "enabled";
     String combination = "combination";
-    String air = "air";
-    String water = "water";
-    String earth = "earth";
-    String fire = "fire";
-    String noBinding = "noBinding";
-    String timeout = "timeout";
-    String elemental = "elemental";
-    String airAltar = "airAltar";
-    String waterAltar = "waterAltar";
-    String earthAltar = "earthAltar";
-    String fireAltar = "fireAltar";
-    String needsDeposit = "needsDeposit";
+    // debug flags were moved to GotrScript
 
     @ConfigSection(
             name = "General",
@@ -96,14 +84,6 @@ public interface GotrConfig extends Config {
         return true;
     }
 
-    @ConfigItem(
-            keyName = enabled,
-            name = "Enabled",
-            description = "Would you like to craft Combination runes?",
-            position = 0,
-            section = combinationSection
-    )
-    default boolean enabled() { return false; }
 
     @ConfigItem(
             keyName = combination,
@@ -114,111 +94,5 @@ public interface GotrConfig extends Config {
     )
     default Combination rune() {return Combination.MIST;}
 
-    @ConfigItem(
-            keyName = noBinding,
-            name = "noBinding",
-            description = "needs to bank?",
-            position = 0,
-            section = debugSection
-    )
-    default boolean noBinding() { return false; }
 
-    @ConfigItem(
-            keyName = timeout,
-            name = "Breaking",
-            description = "needs to break?",
-            position = 1,
-            section = debugSection
-    )
-    default boolean timeout() { return false; }
-
-    @ConfigItem(
-            keyName = elemental,
-            name = "Elemental",
-            description = "is rune Elemental?",
-            position = 2,
-            section = debugSection
-    )
-    default boolean elemental() { return false; }
-
-    @ConfigItem(
-            keyName = air,
-            name = "Air runes combinable?",
-            description = "use air runes for combination?",
-            position = 3,
-            section = debugSection
-    )
-    default boolean air() { return false; }
-
-    @ConfigItem(
-            keyName = water,
-            name = "Water runes combinable?",
-            description = "use water runes for combination?",
-            position = 4,
-            section = debugSection
-    )
-    default boolean water() { return false; }
-
-    @ConfigItem(
-            keyName = earth,
-            name = "Earth runes combinable?",
-            description = "use earth runes for combination?",
-            position = 5,
-            section = debugSection
-    )
-    default boolean earth() { return false; }
-
-    @ConfigItem(
-            keyName = fire,
-            name = "Fire runes combinable?",
-            description = "use fire runes for combination?",
-            position = 6,
-            section = debugSection
-    )
-    default boolean fire() { return false; }
-
-    @ConfigItem(
-            keyName = airAltar,
-            name = "Air Altar?",
-            description = "are we at the Air Altar?",
-            position = 7,
-            section = debugSection
-    )
-    default boolean airAltar() { return false; }
-
-    @ConfigItem(
-            keyName = waterAltar,
-            name = "Water Altar?",
-            description = "are we at the Water Altar?",
-            position = 8,
-            section = debugSection
-    )
-    default boolean waterAltar() { return false; }
-
-    @ConfigItem(
-            keyName = earthAltar,
-            name = "Earth Altar?",
-            description = "are we at the Earth Altar?",
-            position = 9,
-            section = debugSection
-    )
-    default boolean earthAltar() { return false; }
-
-    @ConfigItem(
-            keyName = fireAltar,
-            name = "Fire Altar?",
-            description = "are we at the Fire Altar?",
-            position = 10,
-            section = debugSection
-    )
-    default boolean fireAltar() { return false; }
-
-    @ConfigItem(
-            keyName = needsDeposit,
-            name = "needs Deposit?",
-            description = "are we at the Fire Altar?",
-            position = 11,
-            section = debugSection
-    )
-    default boolean needsDeposit() { return false; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -67,6 +67,18 @@ public class GotrScript extends Script {
 
     boolean initCheck = false;
     boolean optimizedEssenceLoop = false;
+    boolean noBind = false;
+    boolean timeout = false;
+    boolean elemental = false;
+    boolean air = false;
+    boolean water = false;
+    boolean earth = false;
+    boolean fire = false;
+    boolean airAltar = false;
+    boolean waterAltar = false;
+    boolean earthAltar = false;
+    boolean fireAltar = false;
+    boolean needsDeposit = false;
 
     static boolean useNpcContact = true;
     private final List<Integer> runeIds = ImmutableList.of(
@@ -123,11 +135,11 @@ public class GotrScript extends Script {
                     if (!Rs2Magic.isLunar()) {
                         log("Lunar spellbook not found...disabling npc contact");
                         useNpcContact = false;
-                        configManager.setConfiguration(config.configGroup, "enabled", false);
+                        configManager.setConfiguration(config.configGroup, "combination", Combination.NONE);
                     }
                     var magicLevel = Microbot.getClient().getBoostedSkillLevel(Skill.MAGIC);
                     if (magicLevel < 82) {
-                        configManager.setConfiguration(config.configGroup, "enabled", false);
+                        configManager.setConfiguration(config.configGroup, "combination", Combination.NONE);
                     }
                     initCheck = true;
                 }
@@ -145,14 +157,14 @@ public class GotrScript extends Script {
                 }
 
                 if (!Rs2Inventory.hasItem(ItemID.BINDING_NECKLACE) && !Rs2Equipment.isWearing(ItemID.BINDING_NECKLACE)) {
-                    configManager.setConfiguration(config.configGroup, "noBinding", true);
+                    noBind = true;
                 } else {
-                    configManager.setConfiguration(config.configGroup, "noBinding", false);
+                    noBind = false;
                 }
 
                 if (BreakHandlerScript.breakIn <= 300) {
                     BreakHandlerScript.setLockState(true);
-                    configManager.setConfiguration(config.configGroup, "timeout", true);
+                    timeout = true;
                 }
 
                 if (Rs2Inventory.anyPouchUnknown()) {
@@ -202,9 +214,9 @@ public class GotrScript extends Script {
                         //Create fragments into whatever
                         if (isOutOfFragments()) return;
 
-                        if (config.needsDeposit()) {
+                        if (needsDeposit) {
                             if (depositRunesIntoPool()) {
-                                configManager.setConfiguration(config.configGroup, "needsDeposit", "false");
+                                needsDeposit = false;
                             }
                         }
 
@@ -450,13 +462,13 @@ public class GotrScript extends Script {
         TileObject rcAltar = findRcAltar();
         if (rcAltar != null) {
             if (runeId != null) {
-                if (config.enabled()) {
+                if (config.rune() != Combination.NONE) {
                     if (!Rs2Inventory.hasItem(ItemID.AIR_RUNE) && !Rs2Inventory.hasItem(ItemID.WATER_RUNE) && !Rs2Inventory.hasItem(ItemID.EARTH_RUNE) && !Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
-                        configManager.setConfiguration(config.configGroup, "enabled", false);
+                        configManager.setConfiguration(config.configGroup, "combination", Combination.NONE);
                         return true;
                     }
                 }
-                if (config.enabled() && !config.noBinding() && config.elemental()) {
+                if (config.rune() != Combination.NONE && !noBind && elemental) {
                     if (!isInMainRegion() && isInMiniGame()) {
                         if (Rs2Player.isMoving()) {
                             return true;
@@ -478,7 +490,7 @@ public class GotrScript extends Script {
                             sleep(Rs2Random.randomGaussian(Rs2Random.between(1000, 1500), 300));
                             return true;
                         } else if (!Rs2Player.isMoving()) {
-                            configManager.setConfiguration(config.configGroup, "needsDeposit", true);
+                            needsDeposit = true;
                             state = GotrState.LEAVING_ALTAR;
                             TileObject rcPortal = findPortalToLeaveAltar();
                             if (Rs2GameObject.interact(rcPortal.getId())) {
@@ -508,7 +520,7 @@ public class GotrScript extends Script {
                     log("Crafting runes on altar " + rcAltar.getId());
                     sleep(Rs2Random.randomGaussian(Rs2Random.between(1000, 1500), 300));
                 } else if (!Rs2Player.isMoving()) {
-                    configManager.setConfiguration(config.configGroup, "needsDeposit", true);
+                    needsDeposit = true;
                     state = GotrState.LEAVING_ALTAR;
                     TileObject rcPortal = findPortalToLeaveAltar();
                     if (Rs2GameObject.interact(rcPortal.getId())) {
@@ -534,7 +546,7 @@ public class GotrScript extends Script {
             }
         }
 
-        if (config.timeout() || (config.enabled() && config.noBinding())) {
+        if (timeout || (config.rune() != Combination.NONE && noBind)) {
             if (!onBankRun()) {
                 sleepGaussian(1200, 150);
                 return true;
@@ -552,7 +564,7 @@ public class GotrScript extends Script {
 
 
     private boolean enterMinigame() {
-        if (config.timeout() || (config.enabled() && config.noBinding())) {
+        if (timeout || (config.rune() != Combination.NONE && noBind)) {
             if (!onBankRun()) {
                 sleepGaussian(1200, 150);
                 return false;
@@ -610,7 +622,7 @@ public class GotrScript extends Script {
     }
 
     private void mineGuardianRemains() {
-        if (((getGuardiansPower() == 100) || (getGuardiansPower() == 0)) && ((config.timeout() || (config.enabled() && config.noBinding())))) {
+        if (((getGuardiansPower() == 100) || (getGuardiansPower() == 0)) && ((timeout || (config.rune() != Combination.NONE && noBind)))) {
             if (!onBankRun()) {
                 sleepGaussian(1200, 150);
                 return;
@@ -852,63 +864,59 @@ public class GotrScript extends Script {
 
         switch (altarID) {
             case ObjectID.ALTAR_34760: // air
-                configManager.setConfiguration(config.configGroup, "elemental", true);
-                List<String> airElements = List.of("water", "fire", "earth");
-                for (String key : airElements) {
-                    configManager.setConfiguration(config.configGroup, key, true);
-                }
-                configManager.setConfiguration(config.configGroup, "air", false);
-                configManager.setConfiguration(config.configGroup, "airAltar", true);
-                configManager.setConfiguration(config.configGroup, "waterAltar", false);
-                configManager.setConfiguration(config.configGroup, "earthAltar", false);
-                configManager.setConfiguration(config.configGroup, "fireAltar", false);
+                elemental = true;
+                water = true;
+                fire = true;
+                earth = true;
+                air = false;
+                airAltar = true;
+                waterAltar = false;
+                earthAltar = false;
+                fireAltar = false;
                 break;
             case ObjectID.ALTAR_34762: // water
-                configManager.setConfiguration(config.configGroup, "elemental", true);
-                List<String> waterElements = List.of("air", "fire", "earth");
-                for (String key : waterElements) {
-                    configManager.setConfiguration(config.configGroup, key, true);
-                    configManager.setConfiguration(config.configGroup, "airAltar", false);
-                    configManager.setConfiguration(config.configGroup, "waterAltar", true);
-                    configManager.setConfiguration(config.configGroup, "earthAltar", false);
-                    configManager.setConfiguration(config.configGroup, "fireAltar", false);
-                }
-                configManager.setConfiguration(config.configGroup, "water", false);
+                elemental = true;
+                air = true;
+                fire = true;
+                earth = true;
+                water = false;
+                airAltar = false;
+                waterAltar = true;
+                earthAltar = false;
+                fireAltar = false;
                 break;
             case ObjectID.ALTAR_34763: // earth
-                configManager.setConfiguration(config.configGroup, "elemental", true);
-                List<String> earthElements = List.of("water", "fire", "air");
-                for (String key : earthElements) {
-                    configManager.setConfiguration(config.configGroup, key, true);
-                    configManager.setConfiguration(config.configGroup, "airAltar", false);
-                    configManager.setConfiguration(config.configGroup, "waterAltar", false);
-                    configManager.setConfiguration(config.configGroup, "earthAltar", true);
-                    configManager.setConfiguration(config.configGroup, "fireAltar", false);
-                }
-                configManager.setConfiguration(config.configGroup, "earth", false);
+                elemental = true;
+                water = true;
+                fire = true;
+                air = true;
+                earth = false;
+                airAltar = false;
+                waterAltar = false;
+                earthAltar = true;
+                fireAltar = false;
                 break;
             case ObjectID.ALTAR_34764: // fire
-                configManager.setConfiguration(config.configGroup, "elemental", true);
-                List<String> fireElements = List.of("water", "air", "earth");
-                for (String key : fireElements) {
-                    configManager.setConfiguration(config.configGroup, key, true);
-                }
-                configManager.setConfiguration(config.configGroup, "fire", false);
-                configManager.setConfiguration(config.configGroup, "airAltar", false);
-                configManager.setConfiguration(config.configGroup, "waterAltar", false);
-                configManager.setConfiguration(config.configGroup, "earthAltar", false);
-                configManager.setConfiguration(config.configGroup, "fireAltar", true);
+                elemental = true;
+                water = true;
+                air = true;
+                earth = true;
+                fire = false;
+                airAltar = false;
+                waterAltar = false;
+                earthAltar = false;
+                fireAltar = true;
                 break;
             default:
-                configManager.setConfiguration(config.configGroup, "elemental", false);
-                List<String> catalyticElements = List.of("air", "water", "fire", "earth");
-                for (String key : catalyticElements) {
-                    configManager.setConfiguration(config.configGroup, key, false);
-                    configManager.setConfiguration(config.configGroup, "airAltar", false);
-                    configManager.setConfiguration(config.configGroup, "waterAltar", false);
-                    configManager.setConfiguration(config.configGroup, "earthAltar", false);
-                    configManager.setConfiguration(config.configGroup, "fireAltar", false);
-                }
+                elemental = false;
+                air = false;
+                water = false;
+                earth = false;
+                fire = false;
+                airAltar = false;
+                waterAltar = false;
+                earthAltar = false;
+                fireAltar = false;
                 break;
         }
         return currentAltar;
@@ -950,11 +958,11 @@ public class GotrScript extends Script {
             }
         }
 
-        if (!config.enabled()) {
-            if (config.timeout()) {
+        if (config.rune() == Combination.NONE) {
+            if (timeout) {
                 Rs2Bank.walkToBank();
                 Rs2Player.waitForWalking();
-                configManager.setConfiguration(config.configGroup, "timeout", false);
+                timeout = false;
                 BreakHandlerScript.setLockState(false);
                 BreakHandlerScript.breakIn = 0;
                 sleepGaussian(1200, 150);
@@ -963,9 +971,9 @@ public class GotrScript extends Script {
         }
 
         if (Rs2Equipment.isWearing(ItemID.BINDING_NECKLACE)) {
-            configManager.setConfiguration(config.configGroup, "noBinding", false);
-            if (config.timeout()) {
-                configManager.setConfiguration(config.configGroup, "timeout", false);
+            noBind = false;
+            if (timeout) {
+                timeout = false;
                 BreakHandlerScript.setLockState(false);
                 BreakHandlerScript.breakIn = 0;
                 sleepGaussian(1200, 150);
@@ -989,7 +997,7 @@ public class GotrScript extends Script {
                 Rs2Inventory.waitForInventoryChanges(1200);
                 Rs2Bank.closeBank();
             } else {
-                configManager.setConfiguration(config.configGroup, "enabled", false);
+                configManager.setConfiguration(config.configGroup, "combination", Combination.NONE);
                 return false;
             }
         }
@@ -1000,99 +1008,83 @@ public class GotrScript extends Script {
     public Integer finalRune(Combination combo) {
         switch (combo) {
             case MIST: // needs AIR + WATER
-                if (config.waterAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
+                if (waterAltar && air && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
                     return ItemID.AIR_RUNE;
                 }
-                if (config.airAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
+                if (airAltar && water && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
                     return ItemID.WATER_RUNE;
                 }
                 break;
             case MUD: // WATER + EARTH
-                if (config.waterAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
+                if (waterAltar && earth && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
                     return ItemID.EARTH_RUNE;
                 }
-                if (config.earthAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
+                if (earthAltar && water && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
                     return ItemID.WATER_RUNE;
                 }
                 break;
             case DUST: // EARTH + AIR
-                if (config.earthAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
+                if (earthAltar && air && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
                     return ItemID.AIR_RUNE;
                 }
-                if (config.airAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
+                if (airAltar && earth && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
                     return ItemID.EARTH_RUNE;
                 }
                 break;
             case LAVA: // EARTH + FIRE
-                if (config.fireAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
+                if (fireAltar && earth && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
                     return ItemID.EARTH_RUNE;
                 }
-                if (config.earthAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
+                if (earthAltar && fire && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
                     return ItemID.FIRE_RUNE;
                 }
                 break;
             case STEAM: // WATER + FIRE
-                if (config.waterAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
+                if (waterAltar && fire && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
                     return ItemID.FIRE_RUNE;
                 }
-                if (config.fireAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
+                if (fireAltar && water && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
                     return ItemID.WATER_RUNE;
                 }
                 break;
             case SMOKE: // FIRE + AIR
-                if (config.fireAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
+                if (fireAltar && air && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
                     return ItemID.AIR_RUNE;
                 }
-                if (config.airAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
+                if (airAltar && fire && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
                     return ItemID.FIRE_RUNE;
                 }
                 break;
             case ALL:
-                // Gather all valid rune IDs based on config and inventory
+                // Use rune enums to collect valid candidates based on current altar
                 List<Integer> candidates = new ArrayList<>();
 
-                if (config.waterAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
-                    candidates.add(ItemID.AIR_RUNE);
+                Elemental altarRune = null;
+                if (airAltar) {
+                    altarRune = Elemental.AIR;
+                } else if (waterAltar) {
+                    altarRune = Elemental.WATER;
+                } else if (earthAltar) {
+                    altarRune = Elemental.EARTH;
+                } else if (fireAltar) {
+                    altarRune = Elemental.FIRE;
                 }
-                if (config.airAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
-                    candidates.add(ItemID.WATER_RUNE);
-                }
-                if (config.waterAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
-                    candidates.add(ItemID.EARTH_RUNE);
-                }
-                if (config.earthAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
-                    candidates.add(ItemID.WATER_RUNE);
-                }
-                if (config.earthAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
-                    candidates.add(ItemID.AIR_RUNE);
-                }
-                if (config.airAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
-                    candidates.add(ItemID.EARTH_RUNE);
-                }
-                if (config.fireAltar() && config.earth() && Rs2Inventory.hasItem(ItemID.EARTH_RUNE)) {
-                    candidates.add(ItemID.EARTH_RUNE);
-                }
-                if (config.earthAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
-                    candidates.add(ItemID.FIRE_RUNE);
-                }
-                if (config.waterAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
-                    candidates.add(ItemID.FIRE_RUNE);
-                }
-                if (config.fireAltar() && config.water() && Rs2Inventory.hasItem(ItemID.WATER_RUNE)) {
-                    candidates.add(ItemID.WATER_RUNE);
-                }
-                if (config.fireAltar() && config.air() && Rs2Inventory.hasItem(ItemID.AIR_RUNE)) {
-                    candidates.add(ItemID.AIR_RUNE);
-                }
-                if (config.airAltar() && config.fire() && Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {
-                    candidates.add(ItemID.FIRE_RUNE);
+
+                if (altarRune != null) {
+                    for (Elemental rune : Elemental.values()) {
+                        if (rune == altarRune) {
+                            continue; // can't combine with itself
+                        }
+                        if (Rs2Inventory.hasItem(rune.getItemId())) {
+                            candidates.add(rune.getItemId());
+                        }
+                    }
                 }
 
                 if (candidates.isEmpty()) {
-                    // No valid runes found: handle as appropriate (null, exception, fallback)
                     return null;
                 }
-                // Pick one at random
+
                 int idx = ThreadLocalRandom.current().nextInt(candidates.size());
                 return candidates.get(idx);
             default:

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/data/Combination.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/data/Combination.java
@@ -1,6 +1,7 @@
 package net.runelite.client.plugins.microbot.runecrafting.gotr.data;
 
 import lombok.Getter;
+import net.runelite.api.ItemID;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -8,24 +9,27 @@ import java.util.stream.Collectors;
 
 @Getter
 public enum Combination {
-    // Format: (id, lvl, name, ItemID)
-    MIST(15, 6, "Mist rune"),
-    MUD(16, 13, "Mud rune"),
-    DUST(17, 10, "Dust rune"),
-    LAVA(18, 23, "Lava rune"),
-    STEAM(19, 19, "Steam rune"),
-    SMOKE(20, 15, "Smoke rune"),
-    ALL(-1, 23, "All");
+    // Format: (id, lvl, name, itemId)
+    NONE(0, 0, null, 0),
+    MIST(15, 6, "Mist rune", ItemID.MIST_RUNE),
+    MUD(16, 13, "Mud rune", ItemID.MUD_RUNE),
+    DUST(17, 10, "Dust rune", ItemID.DUST_RUNE),
+    LAVA(18, 23, "Lava rune", ItemID.LAVA_RUNE),
+    STEAM(19, 19, "Steam rune", ItemID.STEAM_RUNE),
+    SMOKE(20, 15, "Smoke rune", ItemID.SMOKE_RUNE),
+    AETHER(21, 25, "Aether rune", ItemID.AETHER_RUNE),
+    ALL(-1, 23, "All", 0);
 
     private final int id;
     private final int lvl;
     private final String name;
+    private final int itemId;
 
-
-    Combination(int id, int lvl, String name) {
+    Combination(int id, int lvl, String name, int itemId) {
         this.id = id;
         this.lvl = lvl;
         this.name = name;
+        this.itemId = itemId;
     }
 
     @Override
@@ -40,5 +44,74 @@ public enum Combination {
     // get all ids as a set
     public static Set<Integer> getIds() {
         return Arrays.stream(values()).map(Combination::getId).collect(Collectors.toSet());
+    }
+}
+
+@Getter
+public enum Elemental {
+    AIR(22, 1, "Air rune", ItemID.AIR_RUNE),
+    WATER(23, 5, "Water rune", ItemID.WATER_RUNE),
+    EARTH(24, 9, "Earth rune", ItemID.EARTH_RUNE),
+    FIRE(25, 14, "Fire rune", ItemID.FIRE_RUNE);
+
+    private final int id;
+    private final int lvl;
+    private final String name;
+    private final int itemId;
+
+    Elemental(int id, int lvl, String name, int itemId) {
+        this.id = id;
+        this.lvl = lvl;
+        this.name = name;
+        this.itemId = itemId;
+    }
+
+    @Override
+    public String toString() {
+        return name + " (" + getlvl() + ", " + getItemId() + ")";
+    }
+
+    public int getlvl() {
+        return lvl;
+    }
+
+    public static Set<Integer> getIds() {
+        return Arrays.stream(values()).map(Elemental::getId).collect(Collectors.toSet());
+    }
+}
+
+@Getter
+public enum Catalytic {
+    MIND(26, 2, "Mind rune", ItemID.MIND_RUNE),
+    BODY(27, 20, "Body rune", ItemID.BODY_RUNE),
+    COSMIC(28, 27, "Cosmic rune", ItemID.COSMIC_RUNE),
+    NATURE(29, 44, "Nature rune", ItemID.NATURE_RUNE),
+    LAW(30, 54, "Law rune", ItemID.LAW_RUNE),
+    DEATH(31, 65, "Death rune", ItemID.DEATH_RUNE),
+    BLOOD(32, 77, "Blood rune", ItemID.BLOOD_RUNE);
+
+    private final int id;
+    private final int lvl;
+    private final String name;
+    private final int itemId;
+
+    Catalytic(int id, int lvl, String name, int itemId) {
+        this.id = id;
+        this.lvl = lvl;
+        this.name = name;
+        this.itemId = itemId;
+    }
+
+    @Override
+    public String toString() {
+        return name + " (" + getlvl() + ", " + getItemId() + ")";
+    }
+
+    public int getlvl() {
+        return lvl;
+    }
+
+    public static Set<Integer> getIds() {
+        return Arrays.stream(values()).map(Catalytic::getId).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
## Summary
- keep all rune enums in `Combination.java`
- rename helper enums to `Elemental` and `Catalytic`
- ensure `NONE` and `ALL` appear only on the `Combination` enum
- mark `Elemental` and `Catalytic` enums as `public`
- restore original `toString()` for `Combination`
- use `Combination.NONE` as the configuration toggle instead of `enabled`
- drop `noBinding` from configuration and store state directly in `GotrScript`
- move debug settings from config to fields inside `GotrScript`
- rework random candidate rune logic using enums

## Testing
- `mvn -pl runelite-client -am package -DskipTests` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b90b5bce4832fab3937d9f266fdc5