### PR TITLE
Fix NPE when runecrafting altar missing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -544,6 +544,7 @@ public class GotrScript extends Script {
                 ObjectID.ALTAR_34767, ObjectID.ALTAR_34768, ObjectID.ALTAR_34769, ObjectID.ALTAR_34770,
                 ObjectID.ALTAR_34771, ObjectID.ALTAR_34772, ObjectID.ALTAR_43479};
         TileObject rcAltar = Rs2GameObject.findObject(altarIds);
+        if (rcAltar != null) {
             int altarID = rcAltar.getId();
             switch (altarID) {
                 case ObjectID.ALTAR_34760: // air
@@ -602,7 +603,6 @@ public class GotrScript extends Script {
                     fireAltar = false;
                     break;
             }
-        if (rcAltar != null) {
             if (runeId != null) {
                 if (config.rune() != Combination.NONE) {
                     if (!Rs2Inventory.hasItem(ItemID.AIR_RUNE) && !Rs2Inventory.hasItem(ItemID.WATER_RUNE) && !Rs2Inventory.hasItem(ItemID.EARTH_RUNE) && !Rs2Inventory.hasItem(ItemID.FIRE_RUNE)) {


### PR DESCRIPTION
## Summary
- avoid NullPointerException by only running altar logic when `rcAltar` is found
- reorganize craftRunes to use `if (rcAltar != null)` block