### PR TITLE
Fix GOTR huge mine behavior

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -770,7 +770,7 @@ public class GotrScript extends Script {
         }
         state = GotrState.MINE_LARGE_GUARDIAN_REMAINS;
         if (isInHugeMine()) {
-            leaveHugeMine();
+            mineHugeGuardianRemain();
             return;
         }
         if (Rs2Player.getSkillRequirement(Skill.AGILITY, 56) && getTimeSincePortal() < 85 && !Rs2Inventory.hasItem(GUARDIAN_ESSENCE)) {


### PR DESCRIPTION
## Summary
- stay in huge mine to mine guardian remains instead of immediately exiting
https://chatgpt.com/codex/tasks/task_e_684c81b5c09c832fa6d8d4973ff98f83