### PR TITLE
Fix pouchCheck initialization

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/runecrafting/gotr/GotrScript.java
@@ -160,7 +160,7 @@ public class GotrScript extends Script {
                 if (!pouchCheck) {
                     Rs2Inventory.checkPouches();
                     sleep(Rs2Random.randomGaussian(1500, 300));
-                    pouchCheck = false;
+                    pouchCheck = true;
                 }
 
                 Rs2Walker.setTarget(null);


### PR DESCRIPTION
## Summary
- ensure pouchCheck is set true after the initial pouch check
- keep pouchCheck reset in `mineHugeGuardianRemain()` when rechecking is required